### PR TITLE
API to get colours in a palette

### DIFF
--- a/pages/api/get-colors.ts
+++ b/pages/api/get-colors.ts
@@ -1,0 +1,16 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import palettes from "../../assets/palettes.json";
+
+const handler = (req: NextApiRequest, res: NextApiResponse) => {
+  const { id } = req.query;
+  if (typeof id === "string") {
+    const colors = palettes[id];
+    res.setHeader("Cache-Control", "max-age=0, s-maxage=86400");
+    res.status(200).json({ colors });
+  } else {
+    res.status(404).end();
+  }
+};
+
+export default handler;


### PR DESCRIPTION
Adds an API  route `/api/get-colors?id=<palette_id>` which returns the array of colours in the palette. It's also cached at vercel's edge, so it's fast.